### PR TITLE
changed syntax of dblink_connect

### DIFF
--- a/parallelsql.sql
+++ b/parallelsql.sql
@@ -83,7 +83,7 @@ BEGIN
     conn := 'conn_' || current_proc; 
     RAISE NOTICE 'New Connection name: %',conn;
  
-    sql := 'SELECT dblink_connect(' || QUOTE_LITERAL(conn) || ',' || QUOTE_LITERAL(db) ||');';
+    sql := 'SELECT dblink_connect(' || QUOTE_LITERAL(conn) || ', ''dbname=' || db ||''');';
     execute sql;
 
 


### PR DESCRIPTION
included 'dbname=' into the call, since it didn't run otherwise